### PR TITLE
✨ First version to deploy kind clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,44 @@
 # Base image
 FROM python:3.11-slim
 
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    bash \
+    net-tools \
+    && apt-get clean
+
+# Install Docker CLI to communicate with dind
+RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+
+# Install kind
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64 \
+    && chmod +x ./kind && mv ./kind /usr/local/bin/kind
+
+# Install kubectl
+RUN curl -LO https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
 # Set the working directory
 WORKDIR /app
 
 # Copy dependencies file
 COPY app/requirements.txt /src/requirements.txt
 
-# Install Python dependencies
+# Install python dependencies
 RUN pip install --no-cache-dir -r /src/requirements.txt
 
 # Copy the current directory contents into the container at /app
 COPY app/manager.py /app/manager.py
 
-# Expose Flask app port
+# Expose flask app port for docs
 EXPOSE 5000
 
-# Start the Flask app
-CMD ["python", "manager.py"]
+# Use bridge network in docker
+ENV KIND_EXPERIMENTAL_DOCKER_NETWORK=bridge
 
+# Start the flask app
+CMD ["python", "manager.py"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **Destroy Clusters**: Tear down clusters when they are no longer needed.
 
 ### Requirements:
+
 - Docker
 - Kind
 - Python 3.11+
@@ -68,7 +69,7 @@ Ensure you have Docker and Docker Compose installed and running.
 ### 3. Build and Run the Application:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 This will start the Flask API on port `5000`.
@@ -86,7 +87,37 @@ curl -X POST http://localhost:5000/clusters/deploy
 To view logs from the running containers, use:
 
 ```bash
-docker-compose logs -f
+docker compose logs -f
+```
+
+### 6. Access using Kubectl:
+
+Dump the kubeconfig using the cluster id:
+
+```bash
+curl -s http://localhost:5000/clusters/kubeconfig/kind-8qta2 | jq -r '.kubeconfig' > /tmp/.config
+```
+
+Set the `KUBECONFIG` environment variable to the file:
+
+```bash
+export KUBECONFIG=/tmp/.config
+```
+
+Access the cluster using kubectl:
+
+```bash
+kubectl get nodes
+# NAME                       STATUS   ROLES           AGE   VERSION
+# kind-8qta2-control-plane   Ready    control-plane   39s   v1.27.3
+```
+
+### 7. Destroy the Cluster:
+
+Destroy the cluster by providing the clusterid:
+
+```bash
+curl -XDELETE http://localhost:5000/clusters/kubeconfig/kind-8qta2
 ```
 
 ---

--- a/app/manager.py
+++ b/app/manager.py
@@ -1,3 +1,8 @@
+import subprocess
+import os
+import re
+import random
+import string
 import docker
 from flask import Flask, jsonify, request
 
@@ -6,7 +11,33 @@ app = Flask(__name__)
 # Initialize Docker client using the Docker host defined in the environment
 client = docker.DockerClient(base_url=os.environ['DOCKER_HOST'])
 
-# API: Test Docker via API
+# In-memory storage for clusters
+# TODO: use redis or something similar
+clusters = {}
+
+# Base directory to store kubeconfig files
+KUBECONFIG_DIR = "/tmp/kubeconfigs"
+if not os.path.exists(KUBECONFIG_DIR):
+    os.makedirs(KUBECONFIG_DIR)
+
+# Function: Generate a cluster name
+def generate_cluster_name():
+    return "kind-" + ''.join(random.choices(string.ascii_lowercase + string.digits, k=5))
+
+# Function: Check if a port is available
+def is_port_available(port):
+    with subprocess.Popen(f"netstat -an | grep {port}", shell=True, stdout=subprocess.PIPE) as proc:
+        output = proc.stdout.read()
+    return len(output.strip()) == 0
+
+# Function: Find an available port within defined range
+def find_available_port():
+    while True:
+        port = random.randint(45000, 45010)
+        if is_port_available(port):
+            return port
+
+# API: Test docker
 @app.route("/test-docker", methods=["GET"])
 def test_docker():
     try:
@@ -14,6 +45,119 @@ def test_docker():
         return jsonify({"containers": [c.name for c in containers]}), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+# Function: Deploy a cluster
+def deploy_cluster(cluster_name, host_port):
+    node_ip_address = os.environ['NODE_IP_ADDRESS']
+    kind_config = f"""
+---
+# https://kind.sigs.k8s.io/docs/user/configuration
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # WARNING: It is _strongly_ recommended that you keep this the default
+  # (127.0.0.1) for security reasons. However it is possible to change this.
+  apiServerAddress: "0.0.0.0"
+  # By default the API server listens on a random open port.
+  # You may choose a specific port but probably don't need to in most cases.
+  # Using a random port makes it easier to spin up multiple clusters.
+  apiServerPort: {host_port}
+nodes:
+  - role: control-plane
+kubeadmConfigPatchesJSON6902:
+  - group: kubeadm.k8s.io
+    version: v1beta3
+    kind: ClusterConfiguration
+    patch: |
+      - op: add
+        path: /apiServer/certSANs/-
+        value: {node_ip_address}
+"""
+    kind_config_file = f"{KUBECONFIG_DIR}/{cluster_name}-kindconfig.yaml"
+
+    # Write the config file
+    with open(kind_config_file, "w") as f:
+        f.write(kind_config)
+
+    # Create the cluster
+    subprocess.run(["kind", "create", "cluster", "--name", cluster_name, "--config", kind_config_file])
+
+    # Update kubeconfig
+    kubeconfig_file = f"{KUBECONFIG_DIR}/{cluster_name}-config.yaml"
+
+    result = subprocess.run(
+        ["kind", "get", "kubeconfig", "--name", cluster_name],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+
+    # Check for errors
+    if result.returncode != 0:
+        print(f"Error retrieving kubeconfig: {result.stderr}")
+        return False
+
+    # Write the output to the kubeconfig file
+    with open(kubeconfig_file, "w") as f:
+        f.write(result.stdout)
+
+    # Substitute 0.0.0.0 with Node IP
+    external_ip = os.environ['NODE_IP_ADDRESS']
+    with open(kubeconfig_file, "r") as f:
+        kubeconfig_data = f.read().replace("0.0.0.0", external_ip)
+        kubeconfig_data = re.sub(r":\d+", f":{host_port}", kubeconfig_data)
+
+    with open(kubeconfig_file, "w") as f:
+        f.write(kubeconfig_data)
+
+    # Save cluster details
+    clusters[cluster_name] = {
+        "name": cluster_name,
+        "host_port": host_port,
+        "kubeconfig": kubeconfig_file,
+        "kindconfig": kind_config_file
+    }
+
+    return cluster_name
+
+# Function: Destroy a cluster
+def destroy_cluster(cluster_name):
+    subprocess.run(["kind", "delete", "cluster", "--name", cluster_name])
+    if cluster_name in clusters:
+        del clusters[cluster_name]
+
+# API: Deploy a cluster
+@app.route("/clusters/deploy", methods=["POST"])
+def deploy():
+    cluster_name = generate_cluster_name()
+    host_port = find_available_port()
+    deploy_cluster(cluster_name, host_port)
+    return jsonify({"message": "Cluster deployed", "cluster_name": cluster_name, "port": host_port}), 201
+
+# API: Destroy a cluster
+@app.route("/clusters/destroy/<cluster_name>", methods=["DELETE"])
+def destroy(cluster_name):
+    if cluster_name in clusters:
+        destroy_cluster(cluster_name)
+        return jsonify({"message": f"Cluster {cluster_name} destroyed"}), 200
+    else:
+        return jsonify({"error": "Cluster not found"}), 404
+
+# API: List clusters
+@app.route("/clusters", methods=["GET"])
+def list_clusters():
+    return jsonify(clusters), 200
+
+# API: Get kubeconfig for a cluster
+@app.route("/clusters/kubeconfig/<cluster_name>", methods=["GET"])
+def get_kubeconfig(cluster_name):
+    if cluster_name in clusters:
+        kubeconfig_path = clusters[cluster_name]["kubeconfig"]
+        with open(kubeconfig_path, "r") as f:
+            kubeconfig = f.read()
+        return jsonify({"kubeconfig": kubeconfig}), 200
+    else:
+        return jsonify({"error": "Cluster not found"}), 404
 
 # Run the Flask app
 if __name__ == "__main__":

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,13 @@
+blinker==1.8.2
+certifi==2024.8.30
+charset-normalizer==3.3.2
+click==8.1.7
+docker==7.1.0
 Flask==2.3.3
-docker
+idna==3.10
+itsdangerous==2.2.0
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+requests==2.32.3
+urllib3==2.2.3
+Werkzeug==3.0.4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     privileged: true
     environment:
       - DOCKER_HOST=unix:///var/run/docker.sock
+      - NODE_IP_ADDRESS=192.168.0.50
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:


### PR DESCRIPTION
- checks for available port and overrides kind config to specify port for api server
  - this is done to run more than one cluster at a time
- python client uses the docker host's docker.sock to run kind clusters
  - initially tried using `dind` but had weird networking issues
- specify `NODE_IP_ADDRESS` to configure additional san and sets the address in kubeconfig